### PR TITLE
виділено інтерполяцію кольорів в окремий клас

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/Lab6-KPZ.iml
+++ b/.idea/Lab6-KPZ.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Lab6-KPZ.iml" filepath="$PROJECT_DIR$/.idea/Lab6-KPZ.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MessDetectorOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PHPCSFixerOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PHPCodeSnifferOptionsConfiguration">
+    <option name="highlightLevel" value="WARNING" />
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PhpProjectSharedConfiguration" php_language_level="7.0">
+    <option name="suggestChangeDefaultLanguageLevel" value="false" />
+  </component>
+  <component name="PhpStanOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PsalmOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/index.php
+++ b/index.php
@@ -24,6 +24,7 @@ require_once __DIR__ . '/tools/EraserTool.php';
 require_once __DIR__ . '/tools/GradientTool.php';
 require_once __DIR__ . '/tools/BezierTool.php';
 require_once __DIR__ . '/tools/BrushTool.php';
+require_once __DIR__ . '/tools/ColorInterpolator.php';
 
 if (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest') {
     header('Content-Type: application/json');

--- a/tools/ColorInterpolator.php
+++ b/tools/ColorInterpolator.php
@@ -1,0 +1,19 @@
+<?php
+class ColorInterpolator
+{
+    public static function interpolate(array $startColor, array $endColor, float $ratio): array
+    {
+        return [
+            'r' => $startColor['r'] + ($endColor['r'] - $startColor['r']) * $ratio,
+            'g' => $startColor['g'] + ($endColor['g'] - $startColor['g']) * $ratio,
+            'b' => $startColor['b'] + ($endColor['b'] - $startColor['b']) * $ratio,
+        ];
+    }
+
+    public static function allocateColor($image, array $rgb, float $opacity): int
+    {
+        $alpha = 127 - (int)(($opacity / 100) * 127);
+        return imagecolorallocatealpha($image, $rgb['r'], $rgb['g'], $rgb['b'], $alpha);
+    }
+}
+

--- a/tools/GradientTool.php
+++ b/tools/GradientTool.php
@@ -56,27 +56,14 @@ class GradientTool implements DrawingToolInterface
     private function drawLinearGradient($image)
     {
         $width = abs($this->endX - $this->startX);
-        $height = abs($this->endY - $this->startY);
-
         $x1 = min($this->startX, $this->endX);
         $y1 = min($this->startY, $this->endY);
-        $x2 = max($this->startX, $this->endX);
         $y2 = max($this->startY, $this->endY);
 
         for ($i = 0; $i <= $width; $i++) {
             $ratio = ($width == 0) ? 0 : $i / $width;
-            $r = $this->startColor['r'] + ($this->endColor['r'] - $this->startColor['r']) * $ratio;
-            $g = $this->startColor['g'] + ($this->endColor['g'] - $this->startColor['g']) * $ratio;
-            $b = $this->startColor['b'] + ($this->endColor['b'] - $this->startColor['b']) * $ratio;
-
-            $color = imagecolorallocatealpha(
-                $image,
-                $r,
-                $g,
-                $b,
-                127 - (int)(($this->opacity / 100) * 127)
-            );
-
+            $interpolatedColor = ColorInterpolator::interpolate($this->startColor, $this->endColor, $ratio);
+            $color = ColorInterpolator::allocateColor($image, $interpolatedColor, $this->opacity);
             imageline($image, $x1 + $i, $y1, $x1 + $i, $y2, $color);
         }
     }
@@ -89,18 +76,8 @@ class GradientTool implements DrawingToolInterface
 
         for ($r = $radius; $r >= 0; $r--) {
             $ratio = ($radius == 0) ? 0 : $r / $radius;
-            $rColor = $this->startColor['r'] + ($this->endColor['r'] - $this->startColor['r']) * $ratio;
-            $gColor = $this->startColor['g'] + ($this->endColor['g'] - $this->startColor['g']) * $ratio;
-            $bColor = $this->startColor['b'] + ($this->endColor['b'] - $this->startColor['b']) * $ratio;
-
-            $color = imagecolorallocatealpha(
-                $image,
-                $rColor,
-                $gColor,
-                $bColor,
-                127 - (int)(($this->opacity / 100) * 127)
-            );
-
+            $interpolatedColor = ColorInterpolator::interpolate($this->startColor, $this->endColor, $ratio);
+            $color = ColorInterpolator::allocateColor($image, $interpolatedColor, $this->opacity);
             imagefilledellipse($image, $centerX, $centerY, $r * 2, $r * 2, $color);
         }
     }


### PR DESCRIPTION
**Проблема**
У класі [`GradientTool`](https://github.com/nkhmnk/Lab6-KPZ/blob/main/tools/GradientTool.php) реалізовано дублювання логіки інтерполяції кольорів у методах [`drawLinearGradient`](https://github.com/nkhmnk/Lab6-KPZ/blob/78437b236cc7a1168708d551ad49dab9492175ce/tools/GradientTool.php#L56) та [`drawRadialGradient.`](https://github.com/nkhmnk/Lab6-KPZ/blob/78437b236cc7a1168708d551ad49dab9492175ce/tools/GradientTool.php#L84) В результаті код стає складним для розуміння та підтримки, а також порушується принцип єдиної відповідальності, бо клас відповідає одночасно за процес малювання та за розрахунок кольорів градієнта. Крім того, відсутня централізація обчислень прозорості, що може призводити до помилок при зміні логіки альфа-каналу.

**Запропоноване рішення**
- Винести логіку інтерполяції кольорів та обчислення прозорості в окремий допоміжний клас [`ColorInterpolator`](https://github.com/nkhmnk/Lab6-KPZ/blob/my-feature-branch/tools/ColorInterpolator.php).
- Змінити методи [`drawLinearGradient`](https://github.com/nkhmnk/Lab6-KPZ/blob/6bce408e10187dca889ac92d22ddf632b8c8eac7/tools/GradientTool.php#L56) та [`drawRadialGradient`](https://github.com/nkhmnk/Lab6-KPZ/blob/6bce408e10187dca889ac92d22ddf632b8c8eac7/tools/GradientTool.php#L71) так, щоб вони делегували обчислення кольорів новому класу.
- Покращити читабельність та структуру коду, що полегшить тестування та подальший розвиток функціоналу.
- Зберегти існуючий функціонал без змін, щоб не погіршити надійність.

**Очікуваний результат**
- Код стане більш модульним і зрозумілим.
- Полегшиться підтримка та розширення функціоналу інструменту `Gradient`.
- Знизиться ймовірність помилок при роботі з кольорами і прозорістю.

